### PR TITLE
Add starknet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 	cd blocks/antelope; $(MAKE) --no-print-directory build
 	cd blocks/ethereum; $(MAKE) --no-print-directory build
 	cd blocks/near; $(MAKE) --no-print-directory build
+	cd blocks/starknet; $(MAKE) --no-print-directory build
 
 .PHONY: protogen
 protogen:
@@ -21,12 +22,14 @@ pack:
 	substreams pack
 	substreams pack substreams.antelope.yaml
 	substreams pack substreams.near.yaml
+	substreams pack substreams.starknet.yaml
 
 .PHONY: graph
 graph:
 	substreams graph
 	substreams graph substreams.antelope.yaml
 	substreams graph substreams.near.yaml
+	substreams graph substreams.starknet.yaml
 
 .PHONY: info
 info:
@@ -34,8 +37,8 @@ info:
 
 .PHONY: run
 run:
-	substreams run -e mainnet.eth.streamingfast.io:443 substreams.near.yaml prom_out -s 50000 -t +100000 -o jsonl
+	substreams run -e eth.substreams.pinax.network:9000 prom_out -s -100 -o jsonl
 
 .PHONY: gui
 gui:
-	substreams gui -e mainnet.eth.streamingfast.io:443 kv_out -s 50000 -t +100000
+	substreams gui -e eth.substreams.pinax.network:9000 prom_out -s -100

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
   - [x] WAX
   - [x] Telos
 - [x] Near
+- [x] Starknet
+- [ ] Aptos
 
 ### Quickstart
 
@@ -39,6 +41,8 @@ graph TD;
   map_block_stats[map: map_block_stats]
   sf.ethereum.type.v2.Block[source: sf.ethereum.type.v2.Block] --> map_block_stats
   sf.antelope.type.v1.Block[source: sf.antelope.type.v1.Block] --> map_block_stats
+  sf.near.type.v1.Block[source: sf.near.type.v1.Block] --> map_block_stats
+  zklend.starknet.type.v1.Block[source: zklend.starknet.type.v1.Block] --> map_block_stats
   prom_out[map: prom_out]
   map_block_stats --> prom_out
 ```
@@ -47,7 +51,7 @@ graph TD;
 
 ```yaml
 Package name: subtivity_ethereum
-Version: v0.2.1
+Version: v0.3.0
 Doc: Subtivity for Ethereum
 Modules:
 ----
@@ -55,11 +59,11 @@ Name: map_block_stats
 Initial block: 0
 Kind: map
 Output Type: proto:subtivity.v1.BlockStats
-Hash: aa5dd16dc1185ca3628dd16ff2ebcad68f08688f
+Hash: 93725ab06a11557d2f157350311fb73d3ac7437e
 
 Name: prom_out
 Initial block: 0
 Kind: map
 Output Type: proto:pinax.substreams.sink.prometheus.v1.PrometheusOperations
-Hash: 0003de38e0c5b97cb4fd6f45a5aa784a23275916
+Hash: bacc956d16847b90aa41529c88fe4ed93ec91d33
 ```

--- a/blocks/starknet/Cargo.toml
+++ b/blocks/starknet/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "subtivity_block_stats_starknet"
+version = "0.1.0"
+description = "Subtivity Block stats for Starknet"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+prost = { workspace = true }
+prost-types = { workspace = true }
+substreams = { workspace = true }

--- a/blocks/starknet/Makefile
+++ b/blocks/starknet/Makefile
@@ -1,0 +1,34 @@
+.PHONY: all
+all:
+	make build
+	make pack
+	make graph
+	make info
+
+.PHONY: build
+build:
+	cargo build --target wasm32-unknown-unknown --release
+
+.PHONY: protogen
+protogen:
+	substreams protogen --exclude-paths sf/substreams,google
+
+.PHONY: pack
+pack:
+	substreams pack
+
+.PHONY: graph
+graph:
+	substreams graph
+
+.PHONY: info
+info:
+	substreams info
+
+.PHONY: run
+run:
+	substreams run -e starknet.substreams.pinax.network:9000 map_block_stats -s -10 -o jsonl
+
+.PHONY: gui
+gui:
+	substreams gui -e starknet.substreams.pinax.network:9000 map_block_stats -s -10

--- a/blocks/starknet/README.md
+++ b/blocks/starknet/README.md
@@ -1,0 +1,36 @@
+# **Subtivity** Block for `Near`
+
+### References
+
+- https://github.com/starknet-graph/firehose-starknet/blob/master/proto/zklend/starknet/type/v1/type.proto
+
+### Quickstart
+
+```bash
+$ make
+$ make run
+$ make gui
+```
+
+### Graph
+
+```mermaid
+graph TD;
+  map_block_stats[map: map_block_stats];
+  zklend.starknet.type.v1.Block[source: zklend.starknet.type.v1.Block] --> map_block_stats;
+```
+
+### Modules
+
+```yaml
+Package name: subtivity_block_stats_starknet
+Version: v0.1.0
+Doc: Subtivity Block stats for Starknet
+Modules:
+----
+Name: map_block_stats
+Initial block: 0
+Kind: map
+Output Type: proto:subtivity.v1.BlockStats
+Hash: 006f4c7dde040aae19d74bf599ff933f8e4eeb07
+```

--- a/blocks/starknet/proto/zklend/starknet/type/v1/type.proto
+++ b/blocks/starknet/proto/zklend/starknet/type/v1/type.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package zklend.starknet.type.v1;
+
+option go_package = "github.com/starknet-graph/firehose-starknet/types/pb/zklend/starknet/type/v1;pbacme";
+
+// This file only contains the bare minimum types for the POC. It's far from a complete
+// representation of a StarkNet network's history as required by the Firehose protocol. As a result,
+// any future changes to this schema would require a full re-sync of the StarkNet node.
+
+message Block {
+  uint64 height = 1;
+  bytes hash = 2;
+  bytes prevHash = 3;
+  uint64 timestamp = 4;
+  repeated Transaction transactions = 5;
+}
+
+message Transaction {
+  TransactionType type = 1;
+  bytes hash = 2;
+  repeated Event events = 3;
+}
+
+enum TransactionType {
+  DEPLOY = 0;
+  INVOKE_FUNCTION = 1;
+  DECLARE = 2;
+  L1_HANDLER = 3;
+  DEPLOY_ACCOUNT = 4;
+}
+
+message Event {
+  bytes fromAddr = 1;
+  repeated bytes keys = 2;
+  repeated bytes data = 3;
+}

--- a/blocks/starknet/src/lib.rs
+++ b/blocks/starknet/src/lib.rs
@@ -1,0 +1,35 @@
+#[path = "./pb/zklend.starknet.type.v1.rs"]
+#[allow(dead_code)]
+pub mod starknet;
+pub use self::starknet::Block;
+
+#[path = "../../../src/pb/subtivity.v1.rs"]
+#[allow(dead_code)]
+pub mod pb;
+pub use self::pb::BlockStats;
+
+use std::collections::HashSet;
+
+use substreams::Hex;
+use substreams::errors::Error;
+
+#[substreams::handlers::map]
+pub fn map_block_stats(block: Block) -> Result<BlockStats, Error> {
+    let mut transaction_count: i64 = 0;
+    let mut event_count: i64 = 0;
+    let mut unique_froms = HashSet::new();
+
+    for transaction in block.transactions {
+        transaction_count += 1;
+        event_count += transaction.events.len() as i64;
+        for events in &transaction.events {
+            unique_froms.insert(Hex(&events.from_addr).to_string());
+        }
+    }
+
+    Ok(BlockStats {
+        transaction_traces: transaction_count,
+        trace_calls: event_count,
+        uaw: unique_froms.into_iter().collect(),
+    })
+}

--- a/blocks/starknet/src/pb/mod.rs
+++ b/blocks/starknet/src/pb/mod.rs
@@ -1,0 +1,12 @@
+// @generated
+pub mod zklend {
+    pub mod starknet {
+        pub mod r#type {
+            // @@protoc_insertion_point(attribute:zklend.starknet.type.v1)
+            pub mod v1 {
+                include!("zklend.starknet.type.v1.rs");
+                // @@protoc_insertion_point(zklend.starknet.type.v1)
+            }
+        }
+    }
+}

--- a/blocks/starknet/src/pb/zklend.starknet.type.v1.rs
+++ b/blocks/starknet/src/pb/zklend.starknet.type.v1.rs
@@ -1,0 +1,75 @@
+// @generated
+// This file only contains the bare minimum types for the POC. It's far from a complete
+// representation of a StarkNet network's history as required by the Firehose protocol. As a result,
+// any future changes to this schema would require a full re-sync of the StarkNet node.
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Block {
+    #[prost(uint64, tag="1")]
+    pub height: u64,
+    #[prost(bytes="vec", tag="2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub prev_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint64, tag="4")]
+    pub timestamp: u64,
+    #[prost(message, repeated, tag="5")]
+    pub transactions: ::prost::alloc::vec::Vec<Transaction>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Transaction {
+    #[prost(enumeration="TransactionType", tag="1")]
+    pub r#type: i32,
+    #[prost(bytes="vec", tag="2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag="3")]
+    pub events: ::prost::alloc::vec::Vec<Event>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Event {
+    #[prost(bytes="vec", tag="1")]
+    pub from_addr: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", repeated, tag="2")]
+    pub keys: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TransactionType {
+    Deploy = 0,
+    InvokeFunction = 1,
+    Declare = 2,
+    L1Handler = 3,
+    DeployAccount = 4,
+}
+impl TransactionType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TransactionType::Deploy => "DEPLOY",
+            TransactionType::InvokeFunction => "INVOKE_FUNCTION",
+            TransactionType::Declare => "DECLARE",
+            TransactionType::L1Handler => "L1_HANDLER",
+            TransactionType::DeployAccount => "DEPLOY_ACCOUNT",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "DEPLOY" => Some(Self::Deploy),
+            "INVOKE_FUNCTION" => Some(Self::InvokeFunction),
+            "DECLARE" => Some(Self::Declare),
+            "L1_HANDLER" => Some(Self::L1Handler),
+            "DEPLOY_ACCOUNT" => Some(Self::DeployAccount),
+            _ => None,
+        }
+    }
+}
+// @@protoc_insertion_point(module)

--- a/blocks/starknet/substreams.yaml
+++ b/blocks/starknet/substreams.yaml
@@ -1,0 +1,27 @@
+specVersion: v0.1.0
+package:
+  name: subtivity_block_stats_starknet
+  version: v0.1.0
+  url: https://github.com/pinax-network/pinax-subtivity
+  doc: Subtivity Block stats for Starknet
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ../../target/wasm32-unknown-unknown/release/subtivity_block_stats_starknet.wasm
+
+protobuf:
+  files:
+    - type.proto
+    - subtivity.proto
+  importPaths:
+    - ./proto/zklend/starknet/type/v1
+    - ../../proto/v1
+
+modules:
+  - name: map_block_stats
+    kind: map
+    inputs:
+      - source: zklend.starknet.type.v1.Block
+    output:
+      type: proto:subtivity.v1.BlockStats

--- a/src/sinks.rs
+++ b/src/sinks.rs
@@ -1,6 +1,6 @@
-use substreams::{errors::Error, pb::substreams::Clock, log};
+use substreams::errors::Error;
 use substreams_sink_prometheus::{PrometheusOperations, Counter};
-use substreams_sink_kv::pb::sf::substreams::sink::kv::v1::KvOperations;
+// use substreams::{pb::substreams::Clock, log};
 
 use crate::pb::BlockStats;
 
@@ -16,23 +16,28 @@ pub fn prom_out(stats: BlockStats) -> Result<PrometheusOperations, Error> {
         prom_out.push(Counter::from("transaction_traces").add(stats.transaction_traces as f64));
     }
 
+    // TO-DO
+    // push the daily unique wallets to prometheus
+
     Ok(prom_out)
 }
 
-#[substreams::handlers::map]
-pub fn kv_out(stats: BlockStats, clock: Clock) -> Result<KvOperations, Error> {
-    let mut kv_out = KvOperations::default();
-    let seconds = clock.timestamp.unwrap().seconds;
-    let epoch = (seconds / 86400) * 86400;
+// TO-DO
+// save to internal Substreams store
 
-    let day = epoch / 86400;
-    let value: u8 = 1;
+// #[substreams::handlers::map]
+// pub fn kv_out(stats: BlockStats, clock: Clock) -> Result<KvOperations, Error> {
+//     let seconds = clock.timestamp.unwrap().seconds;
+//     let epoch = (seconds / 86400) * 86400;
 
-    log::debug!("inside the kv_out function:");
+//     let day = epoch / 86400;
+//     let value: u8 = 1;
 
-    for wallet in stats.uaw.iter() {
-        let key = format!("daw:{}:{}", day, wallet);
-        kv_out.push_new(key, &[value], 1);
-    }
-    Ok(kv_out)
-}
+//     log::debug!("inside the kv_out function:");
+
+//     for wallet in stats.uaw.iter() {
+//         let key = format!("daw:{}:{}", day, wallet);
+//         kv_out.push_new(key, &[value], 1);
+//     }
+//     Ok(kv_out)
+// }

--- a/substreams.starknet.yaml
+++ b/substreams.starknet.yaml
@@ -1,0 +1,40 @@
+specVersion: v0.1.0
+package:
+  name: subtivity_starknet
+  version: v0.3.0
+  url: https://github.com/pinax-network/pinax-subtivity
+  doc: Subtivity for Starknet
+
+imports:
+  prometheus: https://github.com/pinax-network/substreams-sink-prometheus.rs/releases/download/v0.1.9/substreams-sink-prometheus-v0.1.9.spkg
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ./target/wasm32-unknown-unknown/release/subtivity.wasm
+
+  block_stats:
+    type: wasm/rust-v1
+    file: ./target/wasm32-unknown-unknown/release/subtivity_block_stats_starknet.wasm
+
+protobuf:
+  files:
+    - subtivity.proto
+  importPaths:
+    - proto/v1
+
+modules:
+  - name: map_block_stats
+    kind: map
+    binary: block_stats
+    inputs:
+      - source: zklend.starknet.type.v1.Block
+    output:
+      type: proto:subtivity.v1.BlockStats
+
+  - name: prom_out
+    kind: map
+    inputs:
+      - map: map_block_stats
+    output:
+      type: proto:pinax.substreams.sink.prometheus.v1.PrometheusOperations


### PR DESCRIPTION
```proto
syntax = "proto3";

package zklend.starknet.type.v1;

option go_package = "github.com/starknet-graph/firehose-starknet/types/pb/zklend/starknet/type/v1;pbacme";

// This file only contains the bare minimum types for the POC. It's far from a complete
// representation of a StarkNet network's history as required by the Firehose protocol. As a result,
// any future changes to this schema would require a full re-sync of the StarkNet node.

message Block {
  uint64 height = 1;
  bytes hash = 2;
  bytes prevHash = 3;
  uint64 timestamp = 4;
  repeated Transaction transactions = 5;
}

message Transaction {
  TransactionType type = 1;
  bytes hash = 2;
  repeated Event events = 3;
}

enum TransactionType {
  DEPLOY = 0;
  INVOKE_FUNCTION = 1;
  DECLARE = 2;
  L1_HANDLER = 3;
  DEPLOY_ACCOUNT = 4;
}

message Event {
  bytes fromAddr = 1;
  repeated bytes keys = 2;
  repeated bytes data = 3;
}
```